### PR TITLE
fixed named export from JSON module for Webpack 5

### DIFF
--- a/dist/bundle.cjs.js
+++ b/dist/bundle.cjs.js
@@ -2,12 +2,13 @@
 
 var countryData = require('country-data');
 var momentTz = require('moment-timezone');
-var latest_json = require('moment-timezone/data/meta/latest.json');
+var zones = require('moment-timezone/data/meta/latest.json');
 var UAParser = require('ua-parser-js');
 
 function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
 
 var momentTz__default = /*#__PURE__*/_interopDefaultLegacy(momentTz);
+var zones__default = /*#__PURE__*/_interopDefaultLegacy(zones);
 var UAParser__default = /*#__PURE__*/_interopDefaultLegacy(UAParser);
 
 function ownKeys(object, enumerableOnly) {
@@ -58,7 +59,7 @@ var getTimezone = function getTimezone() {
 };
 
 var getCountryCode = function getCountryCode() {
-  return countryCode || latest_json.zones[timezone.name] && latest_json.zones[timezone.name].countries[0];
+  return countryCode || zones__default["default"][timezone.name] && zones__default["default"][timezone.name].countries[0];
 };
 
 var getCountry = function getCountry() {

--- a/dist/bundle.esm.js
+++ b/dist/bundle.esm.js
@@ -1,6 +1,6 @@
 import { callingCountries } from 'country-data';
 import momentTz from 'moment-timezone';
-import { zones } from 'moment-timezone/data/meta/latest.json';
+import zones from 'moment-timezone/data/meta/latest.json';
 import UAParser from 'ua-parser-js';
 
 function ownKeys(object, enumerableOnly) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { callingCountries } from 'country-data'
 import momentTz from 'moment-timezone'
-import { zones } from 'moment-timezone/data/meta/latest.json'
+import zones from 'moment-timezone/data/meta/latest.json'
 import UAParser from 'ua-parser-js'
 
 let timezone, countryCode, country, results // eslint-disable-line prefer-const


### PR DESCRIPTION
Fixed import statement so it works with Webpack 5. See https://webpack.js.org/migrate/5/\#using-named-exports-from-json-modules